### PR TITLE
Tokio-based implementation of AsyncDatagramSocket

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,10 @@ members = [
     "async-coap",
     "async-coap-uri",
 	"async-coap-uri/proc-macros",
+    "async-coap-tokio",
 ]
 default-members = [
     "async-coap",
     "async-coap-uri",
+    "async-coap-tokio",
 ]

--- a/async-coap-tokio/Cargo.toml
+++ b/async-coap-tokio/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "async-coap-tokio"
+version = "0.1.0"
+authors = ["Robert Quattlebaum <rquattle@google.com>"]
+edition = "2018"
+description = "Tokio back-end for `async-coap::datagram`"
+repository = "https://github.com/google/rust-async-coap"
+documentation = "https://docs.rs/async-coap-tokio/"
+license = "Apache-2.0"
+readme = "README.md"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-coap = { path = "../async-coap", version = "0.1" }
+tokio-net = "0.2.0-alpha.2"
+mio = "0.6"
+futures-preview = { version = "=0.3.0-alpha.18", features = ["async-await", "nightly"] }
+
+[dev-dependencies]
+tokio = "0.2.0-alpha.2"

--- a/async-coap-tokio/README.md
+++ b/async-coap-tokio/README.md
@@ -1,0 +1,47 @@
+[Tokio][]-based [`AsyncDatagramSocket`][] wrapper for [`async-coap`][]
+======================================================================
+
+[![Crates.io](https://img.shields.io/crates/v/async-coap-tokio.svg)](https://crates.io/crates/async-coap-tokio)
+[![API](https://docs.rs/async-coap-tokio/badge.svg)](https://docs.rs/async-coap-tokio)
+
+This crate provides `TokioAsyncUdpSocket`: an asynchronous, [Tokio][]-based
+implementation of [`AsyncDatagramSocket`] for use with [`DatagramLocalEndpoint`].
+
+[`AsyncDatagramSocket`]: https://docs.rs/async-coap/0.1/async_coap/datagram/trait.AsyncDatagramSocket.html
+[`DatagramLocalEndpoint`]: https://docs.rs/async-coap/0.1/async_coap/datagram/trait.DatagramLocalEndpoint.html
+[Tokio]: https://tokio.rs/
+
+See the [crate documentation](https://docs.rs/async-coap-tokio) for more information.
+
+## Usage ##
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+async-coap = "0.1"
+async-coap-tokio = "0.1"
+```
+
+## License ##
+
+async-coap-tokio is released under the [Apache 2.0 license](../LICENSE).
+
+    Copyright (c) 2019 Google LLC
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+## Disclaimer ##
+
+This is not an officially supported Google product.

--- a/async-coap-tokio/src/lib.rs
+++ b/async-coap-tokio/src/lib.rs
@@ -1,0 +1,24 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! This crate provides [`TokioAsyncUdpSocket`]\: an asynchronous, [Tokio][]-based
+//! implementation of [`AsyncDatagramSocket`] for use with [`DatagramLocalEndpoint`].
+//!
+//! [`AsyncDatagramSocket`]: async-coap::datagram::AsyncDatagramSocket
+//! [`DatagramLocalEndpoint`]: async-coap::datagram::DatagramLocalEndpoint
+//! [Tokio]: https://tokio.rs/
+
+mod tokio_async_udp_socket;
+pub use tokio_async_udp_socket::TokioAsyncUdpSocket;

--- a/async-coap-tokio/tests/test.rs
+++ b/async-coap-tokio/tests/test.rs
@@ -1,0 +1,48 @@
+#![feature(async_await)]
+
+use async_coap::datagram::DatagramLocalEndpoint;
+use async_coap::prelude::*;
+use async_coap_tokio::TokioAsyncUdpSocket;
+use futures::prelude::*;
+use std::sync::Arc;
+use tokio::executor::spawn;
+
+#[tokio::test]
+async fn test_tokio() {
+    let socket = TokioAsyncUdpSocket::bind("[::]:0").expect("UDP bind failed");
+
+    // Create a new local endpoint from the socket we just created,
+    // wrapping it in a `Arc<>` to ensure it can live long enough.
+    let local_endpoint = Arc::new(DatagramLocalEndpoint::new(socket));
+
+    // Add our local endpoint to the pool, so that it
+    // can receive packets.
+    spawn(
+        local_endpoint
+            .clone()
+            .receive_loop_arc(null_receiver!())
+            .map(|err| panic!("Receive loop terminated: {}", err)),
+    );
+
+    // Create a remote endpoint instance to represent the
+    // device we wish to interact with.
+    let remote_endpoint = local_endpoint
+        .remote_endpoint_from_uri(uri!("coap://coap.me"))
+        .unwrap(); // Will only fail if the URI scheme or authority is unrecognizable
+
+    // Create a future that sends a request to a specific path
+    // on the remote endpoint, collecting any blocks in the response
+    // and returning `Ok(OwnedImmutableMessage)` upon success.
+    let future = remote_endpoint.send_to(
+        rel_ref!("large"),
+        CoapRequest::get() // This is a CoAP GET request
+            .accept(ContentFormat::TEXT_PLAIN_UTF8) // We only want plaintext
+            .block2(Some(Default::default())) // Enable block2 processing
+            .emit_successful_collected_response(), // Collect all blocks into a single message
+    );
+
+    // Wait until we get the result of our request.
+    let result = future.await;
+
+    assert!(result.is_ok(), "Error: {:?}", result.err().unwrap());
+}

--- a/async-coap/src/lib.rs
+++ b/async-coap/src/lib.rs
@@ -19,11 +19,14 @@
 //! interface for using and serving CoAP resources. You can either use the [included datagram-based
 //! back-end](datagram) or you can write your own back-end by implementing [`LocalEndpoint`].
 //!
-//! By implementing [datagram::AsyncDatagramSocket], you can use the [provided datagram-based
+//! By implementing [`datagram::AsyncDatagramSocket`], you can use the [provided datagram-based
 //! back-end](datagram) with whatever datagram-based network layer you might want, be it UDP,
-//! DTLS, or even SMS. An implementation for Rust's standard [`std::net::UdpSocket`]
-//! ([`AllowStdUdpSocket`]) is included. A [Tokio](https://tokio.rs)-based implementation is
-//! forthcoming.
+//! DTLS, or even SMS. A [Tokio](https://tokio.rs)-based `UdpSocket` implementation can be found
+//! [here](https://docs.rs/async-coap-tokio)[^AllowStdUdpSocket].
+//!
+//! [^AllowStdUdpSocket]: A naive wrapper around Rust's standard [`std::net::UdpSocket`]
+//! ([`datagram::AllowStdUdpSocket`]) is included in this crate, but it should usually be avoided
+//! in favor of better-performing options, like [`async-coap-tokio::TokioAsyncUdpSocket`].
 //!
 //! ## Design
 //!

--- a/rust-async-coap.iml
+++ b/rust-async-coap.iml
@@ -19,6 +19,11 @@
       <sourceFolder url="file://$MODULE_DIR$/async-coap-uri/examples" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/async-coap-uri/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/async-coap-uri/benches" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/async-coap-tokio/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/async-coap-tokio/examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/async-coap-tokio/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/async-coap-tokio/benches" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/async-coap-tokio/target" />
       <excludeFolder url="file://$MODULE_DIR$/async-coap-uri/proc-macros/target" />
       <excludeFolder url="file://$MODULE_DIR$/async-coap-uri/target" />
       <excludeFolder url="file://$MODULE_DIR$/async-coap/target" />


### PR DESCRIPTION
This pull request provides a [Tokio](https://tokio.rs)-based UDP implementation of `AsyncDatagramSocket` for use with `DatagramLocalEndpoint`.
