### PR TITLE
Fix Travis-CI Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: rust
 rust:
-  - stable
-  - beta
   - nightly
-matrix:
-  allow_failures:
-    - rust: nightly
+#  - stable
+#  - beta
+#matrix:
+#  allow_failures:
+#    - rust: nightly

--- a/async-coap/src/datagram/local_endpoint.rs
+++ b/async-coap/src/datagram/local_endpoint.rs
@@ -395,9 +395,9 @@ mod tests {
 
     #[test]
     fn ping_localhost() {
-        let socket = AllowStdUdpSocket::bind("[::]:12345").expect("UDP bind failed");
+        let socket = AllowStdUdpSocket::bind("127.0.0.1:12345").expect("UDP bind failed");
         let local_endpoint = DatagramLocalEndpoint::new(socket);
-        let dest = "[::1]:12345";
+        let dest = "127.0.0.1:12345";
         let send_desc = Ping::new();
         let future = local_endpoint.send(dest, send_desc);
 


### PR DESCRIPTION
Addresses issue #13.

Note that until `async-await` is stabilized on `stable` and `beta`, the only thing it makes sense to test against is `nightly`.