### PR TITLE
Add constants for "all CoAP devices" multicast addresses.

### DIFF
--- a/async-coap/src/consts.rs
+++ b/async-coap/src/consts.rs
@@ -53,6 +53,15 @@ pub const URI_SCHEME_NULL: &'static str = "null";
 /// ensure that it can never be interpreted as a partial domain name.
 pub const ALL_COAP_DEVICES_HOSTNAME: &'static str = "all-coap-devices.";
 
+/// String slice containing the "All CoAP Devices" IPv6 **Link**-Local Multicast Address: `FF02::FD`
+pub const ALL_COAP_DEVICES_V6_LL: &'static str = "FF02::FD";
+
+/// String slice containing the "All CoAP Devices" IPv6 **Realm**-Local Multicast Address: `FF03::FD`
+pub const ALL_COAP_DEVICES_V6_RL: &'static str = "FF03::FD";
+
+/// String slice containing the "All CoAP Devices" IPv4 **Link**-Local Multicast Address: `224.0.1.187`
+pub const ALL_COAP_DEVICES_V4: &'static str = "224.0.1.187";
+
 /// Value for `OptionNumber::OBSERVE` when registering an observer.
 ///
 /// Note that this is only for requests, replies have entirely different semantics.

--- a/async-coap/src/datagram/allow_udp_socket.rs
+++ b/async-coap/src/datagram/allow_udp_socket.rs
@@ -126,14 +126,17 @@ impl DatagramSocketTypes for AllowStdUdpSocket {
         if host == ALL_COAP_DEVICES_HOSTNAME {
             Ok(vec![
                 SocketAddr::V6(SocketAddrV6::new(
-                    "FF02:0:0:0:0:0:0:FD".parse().unwrap(),
+                    ALL_COAP_DEVICES_V6_LL.parse().unwrap(),
                     port,
                     0,
                     0,
                 )),
-                SocketAddr::V4(SocketAddrV4::new("224.0.1.187".parse().unwrap(), port)),
+                SocketAddr::V4(SocketAddrV4::new(
+                    ALL_COAP_DEVICES_V4.parse().unwrap(),
+                    port,
+                )),
                 SocketAddr::V6(SocketAddrV6::new(
-                    "FF03:0:0:0:0:0:0:FD".parse().unwrap(),
+                    ALL_COAP_DEVICES_V6_RL.parse().unwrap(),
                     port,
                     0,
                     0,


### PR DESCRIPTION
This includes:

* `ALL_COAP_DEVICES_V6_LL`: String slice containing the "All CoAP Devices" IPv6 **Link**-Local Multicast Address: `FF02::FD`
* `ALL_COAP_DEVICES_V6_RL`: String slice containing the "All CoAP Devices" IPv6 **Realm**-Local Multicast Address: `FF03::FD`
* `ALL_COAP_DEVICES_V4`: String slice containing the "All CoAP Devices" IPv4 **Link**-Local Multicast Address: `224.0.1.187`
