### PR TITLE
async-coap-uri: Make `AnyUriRef::write_to` (and friends) unsafe.

### DIFF
--- a/async-coap-uri/src/lib.rs
+++ b/async-coap-uri/src/lib.rs
@@ -185,6 +185,7 @@ pub use uri_type::UriType;
 
 mod any_uri_ref;
 pub use any_uri_ref::AnyUriRef;
+pub use any_uri_ref::AnyUriRefExt;
 pub use any_uri_ref::UriDisplay;
 
 mod error;
@@ -251,9 +252,9 @@ pub use async_coap_uri_macros::assert_rel_ref_literal;
 #[doc(hidden)]
 pub mod prelude {
     pub use super::escape::StrExt;
-    pub use super::AnyUriRef;
     pub use super::UriRawComponents;
     pub use super::{rel_ref, uri, uri_ref};
+    pub use super::{AnyUriRef, AnyUriRefExt};
     pub use super::{RelRef, Uri, UriRef};
 
     pub use {assert_rel_ref_literal, assert_uri_literal, assert_uri_ref_literal};

--- a/async-coap-uri/src/macros.rs
+++ b/async-coap-uri/src/macros.rs
@@ -313,13 +313,6 @@ macro_rules! impl_uri_traits {
                 self.0.components()
             }
 
-            fn write_to<W: core::fmt::Write + ?Sized>(
-                &self,
-                write: &mut W,
-            ) -> Result<(), core::fmt::Error> {
-                self.0.write_to(write)
-            }
-
             fn is_empty(&self) -> bool {
                 self.0.is_empty()
             }
@@ -332,19 +325,11 @@ macro_rules! impl_uri_traits {
                 self.0.to_uri_ref_buf()
             }
 
-            fn write_resolved<W: core::fmt::Write + ?Sized, D: $crate::AnyUriRef + ?Sized>(
+            unsafe fn write_to_unsafe<W: core::fmt::Write + ?Sized>(
                 &self,
-                dest: &D,
-                output: &mut W,
-            ) -> Result<(), $crate::ResolveError> {
-                self.0.write_resolved(dest, output)
-            }
-
-            fn resolved<W: $crate::AnyUriRef + ?Sized>(
-                &self,
-                dest: &W,
-            ) -> Result<$crate::UriRefBuf, $crate::ResolveError> {
-                self.0.resolved(dest)
+                write: &mut W,
+            ) -> Result<(), core::fmt::Error> {
+                self.0.write_to_unsafe(write)
             }
         }
     };
@@ -389,15 +374,6 @@ macro_rules! _impl_uri_buf_traits_base {
                 b.components()
             }
 
-            fn write_to<W: core::fmt::Write + ?Sized>(
-                &self,
-                write: &mut W,
-            ) -> Result<(), core::fmt::Error> {
-                use core::borrow::Borrow;
-                let b: &$B = self.borrow();
-                b.write_to(write)
-            }
-
             fn is_empty(&self) -> bool {
                 use core::borrow::Borrow;
                 let b: &$B = self.borrow();
@@ -416,23 +392,13 @@ macro_rules! _impl_uri_buf_traits_base {
                 b.to_uri_ref_buf()
             }
 
-            fn write_resolved<W: core::fmt::Write + ?Sized, D: $crate::AnyUriRef + ?Sized>(
+            unsafe fn write_to_unsafe<W: core::fmt::Write + ?Sized>(
                 &self,
-                dest: &D,
-                output: &mut W,
-            ) -> Result<(), $crate::ResolveError> {
+                write: &mut W,
+            ) -> Result<(), core::fmt::Error> {
                 use core::borrow::Borrow;
                 let b: &$B = self.borrow();
-                b.write_resolved(dest, output)
-            }
-
-            fn resolved<W: $crate::AnyUriRef + ?Sized>(
-                &self,
-                dest: &W,
-            ) -> Result<$crate::UriRefBuf, $crate::ResolveError> {
-                use core::borrow::Borrow;
-                let b: &$B = self.borrow();
-                b.resolved(dest)
+                b.write_to_unsafe(write)
             }
         }
     };

--- a/async-coap-uri/src/rel_ref.rs
+++ b/async-coap-uri/src/rel_ref.rs
@@ -115,7 +115,7 @@ impl Default for &mut RelRef {
 }
 
 impl AnyUriRef for RelRef {
-    fn write_to<T: core::fmt::Write + ?Sized>(
+    unsafe fn write_to_unsafe<T: core::fmt::Write + ?Sized>(
         &self,
         write: &mut T,
     ) -> Result<(), core::fmt::Error> {

--- a/async-coap-uri/src/uri.rs
+++ b/async-coap-uri/src/uri.rs
@@ -57,7 +57,7 @@ impl AsRef<UriRef> for Uri {
 }
 
 impl AnyUriRef for Uri {
-    fn write_to<T: core::fmt::Write + ?Sized>(
+    unsafe fn write_to_unsafe<T: core::fmt::Write + ?Sized>(
         &self,
         write: &mut T,
     ) -> Result<(), core::fmt::Error> {

--- a/async-coap-uri/src/uri_raw_components.rs
+++ b/async-coap-uri/src/uri_raw_components.rs
@@ -44,7 +44,10 @@ impl AnyUriRef for UriRawComponents<'_> {
     /// Note that the implementation of this method for [`UriRawComponents`] ignores
     /// the value of `self.userinfo`, `self.host`, and `self.port`; instead relying entirely
     /// on `self.authority`.
-    fn write_to<T: core::fmt::Write + ?Sized>(&self, f: &mut T) -> Result<(), core::fmt::Error> {
+    unsafe fn write_to_unsafe<T: core::fmt::Write + ?Sized>(
+        &self,
+        f: &mut T,
+    ) -> Result<(), core::fmt::Error> {
         // Note that everything in `self` is already escaped, so we
         // don't need to do that here.
         if let Some(scheme) = self.scheme {

--- a/async-coap-uri/src/uri_ref.rs
+++ b/async-coap-uri/src/uri_ref.rs
@@ -113,7 +113,7 @@ impl Default for &mut UriRef {
 }
 
 impl AnyUriRef for UriRef {
-    fn write_to<T: core::fmt::Write + ?Sized>(
+    unsafe fn write_to_unsafe<T: core::fmt::Write + ?Sized>(
         &self,
         write: &mut T,
     ) -> Result<(), core::fmt::Error> {


### PR DESCRIPTION
From the rustdocs for [`AnyUriRef::write_to`][]:

> ### Safety
>
> Calling this method is not unsafe, *but implementing it is*! The underlying guarantee is that the written URI reference SHALL be well-formed. If this method writes out something that is not a valid URI reference, the resulting behavior is undefined.

That this method is safe to use but "unsafe" to implement seems problematic in its current form.

This change creates a new automatically-assigned trait, `AnyUriRefExt`, and moves all of the methods from `AnyUriRef` that should not be overridden into it. The previous `AnyUriRef::write_to` method is made unsafe and renamed to `AnyUriRef::write_to_unsafe`. A new method, `AnyUriRefExt::write_to` is added that simply calls `unsafe { self.write_to_unsafe(write) }`.

This arrangement continues to allow the behavior of `write_to` to be changed, but instead of overriding it directly you must now override `AnyUriRef::write_to_unsafe`.

This change also deals with a similar problem with `write_resolved`, except in that case the entire method was simply moved to `AnyUriRefExt` to prevent it from being overridden at all.

[`AnyUriRef::write_to`]: https://docs.rs/async-coap/0.1.0/async_coap/uri/trait.AnyUriRef.html#method.write_to

Fixes #8