### PR TITLE
add send/sync bounds to prevent data race to RC of ArcGuard<Rc, T>

### DIFF
--- a/async-coap/src/arc_guard.rs
+++ b/async-coap/src/arc_guard.rs
@@ -160,8 +160,8 @@ impl<RC, T> ArcGuard<RC, T> {
     }
 }
 
-unsafe impl<RC, T: Send> Send for ArcGuard<RC, T> {}
-unsafe impl<RC, T: Sync> Sync for ArcGuard<RC, T> {}
+unsafe impl<RC: Send, T: Send> Send for ArcGuard<RC, T> {}
+unsafe impl<RC: Sync, T: Sync> Sync for ArcGuard<RC, T> {}
 
 impl<RC, T> Deref for ArcGuard<RC, T> {
     type Target = T;


### PR DESCRIPTION
Fixes #33

This PR adds appropriate Send/Sync trait bounds to the Send/Sync impls of `ArcGuard<RC, T>`,
in order to prevent unsound programs at compile time.

Thank you for reviewing this PR :+1: 