### PR TITLE
Replace println with log macros

### DIFF
--- a/async-coap/src/datagram/response_tracker.rs
+++ b/async-coap/src/datagram/response_tracker.rs
@@ -120,7 +120,7 @@ impl<IC: InboundContext> ResponseTracker<IC> for UdpResponseTracker<IC> {
         //       It feels like there must be a different way, but after 8+ hours of lifetime hell
         //       I couldn't figure it out.
         let handler: Arc<Mutex<dyn HandleResponse<IC>>> = unsafe { std::mem::transmute(handler) };
-        println!(
+        log::info!(
             "Adding response handler: msg_id:{:04X}, msg_token:{}",
             msg_id, msg_token
         );

--- a/async-coap/src/datagram/send_future.rs
+++ b/async-coap/src/datagram/send_future.rs
@@ -189,7 +189,7 @@ where
         // We always control the msg_id.
         builder.set_msg_id(self.msg_id.get());
 
-        println!("OUTBOUND: {} {}", self.dest, builder);
+        log::info!("OUTBOUND: {} {}", self.dest, builder);
 
         let buffer: &[u8] = &builder;
 
@@ -203,11 +203,11 @@ where
             .expect("send_to blocked")
             .err()
         {
-            println!("send_to: io error: {:?} (dest={:?})", e, self.dest);
+            log::warn!("send_to: io error: {:?} (dest={:?})", e, self.dest);
             return Err(Error::IOError);
         }
 
-        println!("Did transmit.");
+        log::info!("Did transmit.");
 
         self.retransmit_count.set(0);
 
@@ -236,7 +236,7 @@ where
 
         builder.set_msg_id(self.msg_id.get());
 
-        println!(
+        log::info!(
             "OUTBOUND[{}]: {} {}",
             self.retransmit_count.get() + 1,
             self.dest,
@@ -255,13 +255,13 @@ where
             .expect("send_to blocked")
             .err()
         {
-            println!("send_to: io error: {:?} (dest={:?})", e, self.dest);
+            log::warn!("send_to: io error: {:?} (dest={:?})", e, self.dest);
             return Err(Error::IOError);
         }
 
         self.retransmit_count.set(self.retransmit_count.get() + 1);
 
-        println!("Did retransmit, count {}", self.retransmit_count.get());
+        log::info!("Did retransmit, count {}", self.retransmit_count.get());
 
         Ok(())
     }
@@ -293,7 +293,7 @@ where
                 && message.msg_code().is_empty()
                 && message.msg_type().is_ack()
             {
-                println!("Got ack!");
+                log::info!("Got ack!");
 
                 self.change_state(UdpSendFutureState::PassivelyWaiting);
                 let d = self.send_desc.max_rtt();
@@ -474,7 +474,7 @@ where
         let inner = match self.inner.lock() {
             Ok(guard) => guard,
             Err(poisoned) => {
-                eprintln!("UdpSendFuture mutex inner was poisoned, locking anyway to drop");
+                log::error!("UdpSendFuture mutex inner was poisoned, locking anyway to drop");
                 poisoned.into_inner()
             }
         };

--- a/async-coap/src/message/codec.rs
+++ b/async-coap/src/message/codec.rs
@@ -116,12 +116,12 @@ pub fn encode_option_without_value(
 
     let calc_len = calc_option_size(prev_key, key, value_len);
     if calc_len > buffer.len() {
-        eprintln!("calc_len:{}, blen:{}", calc_len, buffer.len());
+        log::warn!("calc_len:{}, blen:{}", calc_len, buffer.len());
         return Err(Error::OutOfSpace);
     }
 
     if value_len > MAX_OPTION_VALUE_SIZE {
-        eprintln!("value_len:{}, max:{}", value_len, MAX_OPTION_VALUE_SIZE);
+        log::warn!("value_len:{}, max:{}", value_len, MAX_OPTION_VALUE_SIZE);
         return Err(Error::InvalidArgument);
     }
 
@@ -268,7 +268,7 @@ pub fn insert_option(
 
     // Do a space check before we start trying to move buffers around.
     if len + adj_size > buffer.len() {
-        println!(
+        log::warn!(
             "len:{} + adj_size:{} > blen:{}",
             len,
             adj_size,


### PR DESCRIPTION
If an application uses async-coap as a library, stdout is flooded with logs
coming from async-coap. Replacing println macro invocation with macros from
the log crate allows the application to flexibly manage logs from the library.